### PR TITLE
Removed Assets from Navigation

### DIFF
--- a/views/navigation.json
+++ b/views/navigation.json
@@ -9,24 +9,6 @@
                 "open": false,
                 "items": [
                     {
-                        "icon": "icon icon-assets",
-                        "open": false,
-                        "state": {
-                            "name": "main.modules.list",
-                            "parameters": {
-                                "module": "assets"
-                            }
-                        },
-                        "title": "Assets",
-                        "require": {
-                            "action": "read",
-                            "module": "assets"
-                        },
-                        "editMode": false,
-                        "isEnabled": false,
-                        "openStatus": false
-                    },
-                    {
                         "icon": "icon icon-scans",
                         "open": false,
                         "state": {


### PR DESCRIPTION
Removed `Asset` module from the navigation of Vulnerability Management SP