### PR TITLE
Updated Playbooks

### DIFF
--- a/playbooks/10 - SP - Vulnerability Management/Create or Update Alert for High Risk Asset.json
+++ b/playbooks/10 - SP - Vulnerability Management/Create or Update Alert for High Risk Asset.json
@@ -73,30 +73,6 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Mark Alert as Ready to Investigate",
-            "description": "Update alert state as \"Ready to Investigate\"",
-            "arguments": {
-                "resource": {
-                    "state": "\/api\/3\/picklists\/8675a07f-2d0d-4e3a-89af-4822b8341df8",
-                    "status": "\/api\/3\/picklists\/7de816ff-7140-4ee5-bd05-93ce22002146"
-                },
-                "_showJson": false,
-                "operation": "Append",
-                "collection": "{{vars.steps.Create_Alert['@id']}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/alerts",
-                "fieldOperation": [],
-                "step_variables": []
-            },
-            "status": null,
-            "top": "840",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "group": null,
-            "uuid": "660e5368-4573-48ad-9edd-b3916db6c696"
-        },
-        {
-            "@type": "WorkflowStep",
             "name": "Add Comment for New Vulnerabilities",
             "description": null,
             "arguments": {
@@ -227,7 +203,7 @@
                 "resource": {
                     "name": "Asset {{vars.input.params.assetMetadata.hostname}} found at risk",
                     "type": "\/api\/3\/picklists\/6bf60659-76c2-48c4-9171-8c8c16f3b85e",
-                    "state": "\/api\/3\/picklists\/501d0562-89a0-4079-9a9e-cdde7d34e3ed",
+                    "state": "\/api\/3\/picklists\/a1bac09b-1441-45aa-ad1b-c88744e48e72",
                     "__link": {
                         "scans": "{{vars.input.params.scanIRI}}",
                         "assets": "{{vars.assetIRI}}",
@@ -335,15 +311,6 @@
         }
     ],
     "routes": [
-        {
-            "@type": "WorkflowRoute",
-            "name": "Create Alert -> Mark Alert as Investigating",
-            "targetStep": "\/api\/3\/workflow_steps\/660e5368-4573-48ad-9edd-b3916db6c696",
-            "sourceStep": "\/api\/3\/workflow_steps\/c4606e07-d595-443b-845a-63d111985c8d",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "187a4eb3-2893-4f8b-b1f1-57e584c777cd"
-        },
         {
             "@type": "WorkflowRoute",
             "name": "Fetch Open VM Alert -> Is Alert Exists",

--- a/playbooks/10 - SP - Vulnerability Management/High Risk Vulnerability Response.json
+++ b/playbooks/10 - SP - Vulnerability Management/High Risk Vulnerability Response.json
@@ -117,7 +117,6 @@
             "description": "Unlink all the asset vulnerabilities and update asset criticality to Low",
             "arguments": {
                 "resource": {
-                    "criticality": "\/api\/3\/picklists\/207ae9ec-9a2c-4966-a67d-4964aa40c81d",
                     "vulnerabilities": "[]"
                 },
                 "_showJson": false,
@@ -183,11 +182,11 @@
                         {
                             "type": "object",
                             "field": "state",
-                            "value": "\/api\/3\/picklists\/8675a07f-2d0d-4e3a-89af-4822b8341df8",
+                            "value": "\/api\/3\/picklists\/501d0562-89a0-4079-9a9e-cdde7d34e3ed",
                             "_value": {
-                                "@id": "\/api\/3\/picklists\/8675a07f-2d0d-4e3a-89af-4822b8341df8",
-                                "display": "Ready to Investigate",
-                                "itemValue": "Ready to Investigate"
+                                "@id": "\/api\/3\/picklists\/501d0562-89a0-4079-9a9e-cdde7d34e3ed",
+                                "display": "Indicator Extracted",
+                                "itemValue": "Indicator Extracted"
                             },
                             "operator": "eq"
                         }

--- a/playbooks/10 - SP - Vulnerability Management/Scenario - Create or Update Asset Records for Scan.json
+++ b/playbooks/10 - SP - Vulnerability Management/Scenario - Create or Update Asset Records for Scan.json
@@ -150,7 +150,7 @@
                     "input": {
                         "params": []
                     },
-                    "assetData": "[\n  {\n    \"uuid\": \"2737271e-7142-11ed-b6f2-acde48001122\",\n    \"time_end\": \"2019-01-15T12:38:48.039Z\",\n    \"os\": [\n      \"Microsoft Windows 10 Pro\"\n    ],\n    \"fqdn\": [\n      \"cs-win-11\"\n    ],\n    \"ip\": [\n      \"179.82.38.176\"\n    ],\n    \"mac\": [\n      \"3c:22:fb:28:2e:19\"\n    ],\n    \"time_start\": \"2019-01-15T11:56:35.415Z\"\n  },\n  {\n    \"uuid\": \"273941a2-7142-11ed-b6f2-acde48001122\",\n    \"time_end\": \"2019-01-15T12:38:48.039Z\",\n    \"os\": [\n      \"Microsoft Windows 10 Pro\"\n    ],\n    \"fqdn\": [\n      \"cs-win-12\"\n    ],\n    \"ip\": [\n      \"88.231.203.64\"\n    ],\n    \"mac\": [\n      \"3c:22:fb:28:2e:19\"\n    ],\n    \"time_start\": \"2019-01-15T11:56:35.415Z\"\n  },\n  {\n    \"uuid\": \"273afd08-7142-11ed-b6f2-acde48001122\",\n    \"time_end\": \"2019-01-15T12:38:48.039Z\",\n    \"os\": [\n      \"Microsoft Windows 10 Pro\"\n    ],\n    \"fqdn\": [\n      \"cs-win-13\"\n    ],\n    \"ip\": [\n      \"195.0.3.230\"\n    ],\n    \"mac\": [\n      \"3c:22:fb:28:2e:19\"\n    ],\n    \"time_start\": \"2019-01-15T11:56:35.415Z\"\n  }\n]"
+                    "assetData": "[\n  {\n    \"uuid\": \"2737271e-7142-11ed-b6f2-acde48001122\",\n    \"time_end\": \"2019-01-15T12:38:48.039Z\",\n    \"os\": [\n      \"Microsoft Windows 10 Pro\"\n    ],\n    \"fqdn\": [\n      \"cs-win-11\"\n    ],\n    \"ip\": [\n      \"192.168.0.1\"\n    ],\n    \"mac\": [\n      \"3c:22:fb:28:2e:19\"\n    ],\n    \"time_start\": \"2019-01-15T11:56:35.415Z\"\n  },\n  {\n    \"uuid\": \"273941a2-7142-11ed-b6f2-acde48001122\",\n    \"time_end\": \"2019-01-15T12:38:48.039Z\",\n    \"os\": [\n      \"Microsoft Windows 10 Pro\"\n    ],\n    \"fqdn\": [\n      \"cs-win-12\"\n    ],\n    \"ip\": [\n      \"192.168.0.2\"\n    ],\n    \"mac\": [\n      \"3c:22:fb:28:2e:19\"\n    ],\n    \"time_start\": \"2019-01-15T11:56:35.415Z\"\n  },\n  {\n    \"uuid\": \"273afd08-7142-11ed-b6f2-acde48001122\",\n    \"time_end\": \"2019-01-15T12:38:48.039Z\",\n    \"os\": [\n      \"Microsoft Windows 10 Pro\"\n    ],\n    \"fqdn\": [\n      \"cs-win-13\"\n    ],\n    \"ip\": [\n      \"192.168.0.3\"\n    ],\n    \"mac\": [\n      \"3c:22:fb:28:2e:19\"\n    ],\n    \"time_start\": \"2019-01-15T11:56:35.415Z\"\n  }\n]"
                 }
             },
             "status": null,
@@ -209,7 +209,7 @@
                 "version": "1.2.0",
                 "connector": "tenable-io",
                 "operation": "get_scan_assets",
-                "mock_result": "{% if vars.scanId == 52 %}\n{\n  \"data\": {{vars.assetData[:2]}},\n  \"status\": \"Success\",\n  \"operation\": \"get_scan_assets\",\n  \"message\": \"\"\n}\n{% else %}\n{\n  \"data\": {{vars.assetData}},\n  \"status\": \"Success\",\n  \"operation\": \"get_scan_assets\",\n  \"message\": \"\"\n}\n{% endif %}",
+                "mock_result": "{% if vars.scanId == 52 %}\n{\n  \"data\": {{vars.assetData[:2]}},\n  \"status\": \"Success\",\n  \"operation\": \"get_scan_assets\",\n  \"message\": \"\"\n}\n{% else %}\n{\n  \"data\": {{vars.assetData[1:3]}},\n  \"status\": \"Success\",\n  \"operation\": \"get_scan_assets\",\n  \"message\": \"\"\n}\n{% endif %}",
                 "operationTitle": "List Scan's Assets",
                 "step_variables": {
                     "ipList": "{{vars.result.data | json_query(\"[].ip\")| flatten(levels=1)}}"


### PR DESCRIPTION
1. Scenario - Create or Update Asset Records for Scan
- Updated Mock Data, changed IP addresses to common CIDR range instead of using actual IPs

2. Create or Update Alert for High Risk Asset
- Removed step "Mark Alert as Ready to Investigate" from playbook(due to product bug, the same record was getting updated twice causing response playbook to trigger multiple times)

3. High Risk Vulnerability Response
- Due to changes made in "Create or Update Alert for High Risk Asset" playbook, the On Update trigger condition need to be changed
- The playbooks now triggers on update of alert status to "Indicator Extracted"